### PR TITLE
Add rdb_ref: e2e-test to shim to match @e2e-test uses: ref

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -43,10 +43,11 @@ jobs:
       (startsWith(github.event.comment.body, '/agent-') || startsWith(github.event.comment.body, '/agent ')) &&
       contains(fromJson('["OWNER","COLLABORATOR","MEMBER"]'), github.event.comment.author_association)
     uses: gnovak/remote-dev-bot/.github/workflows/remote-dev-bot.yml@e2e-test
+    with:
+      rdb_ref: e2e-test
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       RDB_PAT_TOKEN: ${{ secrets.RDB_PAT_TOKEN }}
       RDB_APP_PRIVATE_KEY: ${{ secrets.RDB_APP_PRIVATE_KEY }}
-


### PR DESCRIPTION
The reusable workflow now requires an explicit `rdb_ref` input to know which branch to fetch config files from (fix: gnovak/remote-dev-bot#218). Without it, config was always fetched from `main` even when the shim called a non-main ref.

This shim uses `@e2e-test`, so add `rdb_ref: e2e-test` to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)