### PR TITLE
config: cheap single-model council for workshop and build e2e tests

### DIFF
--- a/remote-dev-bot.yaml
+++ b/remote-dev-bot.yaml
@@ -1,6 +1,16 @@
-# remote-dev-bot config for rdb-test
-# This repo is used as the test target for e2e runs.
-# Disable assignment so test issues/PRs are not assigned to the triggering user.
+# rdb-test repo config — keep testing cheap.
+# Base config at gnovak/remote-dev-bot defines all modes and models.
+# Override only what needs to differ for a test repo.
+
 agent:
   assign_issue: false
   assign_pr: false
+
+modes:
+  workshop:
+    council:
+      - claude-small    # Single model council keeps e2e tests cheap
+
+  build:
+    council:
+      - claude-small    # Single model council keeps e2e tests cheap


### PR DESCRIPTION
## Summary

- Adds `modes.workshop.council` and `modes.build.council` overrides, each set to a single `claude-small` model
- Preserves the existing `agent.assign_issue: false` / `assign_pr: false` settings
- All other config falls through to the base config at `gnovak/remote-dev-bot`

## Why

E2e test runs trigger workshop and build modes. With a multi-model council those runs cost ~$3 each. A single cheap model keeps automated testing affordable without changing how the bot behaves structurally.

## Test plan

- [ ] Verify bot picks up the config and uses `claude-small` for workshop/build council in a test run
- [ ] Confirm other modes (review, etc.) still use base-config defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)